### PR TITLE
fix crash on card number input

### DIFF
--- a/ui/src/main/kotlin/com/midtrans/sdk/uikit/internal/util/SnapCreditCardUtil.kt
+++ b/ui/src/main/kotlin/com/midtrans/sdk/uikit/internal/util/SnapCreditCardUtil.kt
@@ -58,7 +58,7 @@ internal object SnapCreditCardUtil {
         rawCardNumber: TextFieldValue,
         isBinBlocked: Boolean
     ): Boolean {
-        val cardNumber = getCardNumberFromTextField(rawCardNumber)
+        val cardNumber = getCardNumberFromTextField(formatCreditCardNumber(rawCardNumber))
         val formattedCardNumberLength = formatCreditCardNumber(rawCardNumber).text.length
 
         return isBinBlocked


### PR DESCRIPTION
1. Fix crash when inputting non-digit random character to card number textfield